### PR TITLE
DOC: Add a link to Modin on the ecosystem page.

### DIFF
--- a/docs/source/ecosystem.rst
+++ b/docs/source/ecosystem.rst
@@ -34,6 +34,9 @@ DataFrame
   GPU-enabled dataframes which can be used as partitions in Dask Dataframes.
 - `dask-geopandas <https://github.com/geopandas/dask-geopandas>`_: Early-stage subproject of
   geopandas, enabling parallelization of geopandas dataframes.
+- `Modin <https://modin.readthedocs.io/en/latest/development/using_pandas_on_dask.html>`_: Scale your
+  pandas workflows by changing one line of code. Modin transparently distributes the data and computation
+  using different execution engines such as Ray, Dask or MPI.
 
 SQL
 ~~~


### PR DESCRIPTION
- [x] Is part of 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Hello, I'm Kirill from the Modin group.
We've implemented conversion to and from Modin from the Dask Dataframe, so we'd like to share this point in your documentation to improve the data science  experience for Dask and Modin users.
I tried to post a detailed description on the ecosystem page, but I think it would be better to add a dataframe-modin subpage for this.
Can you suggest a better place for this?